### PR TITLE
Add new field

### DIFF
--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -169,11 +169,15 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
         scope=Scope.user_state,
     )
 
+    # settings to automatically mark this block as completed when content is loaded if it's true.
     mark_completion_on_open = Boolean(
         default=False,
         scope=Scope.settings,
         display_name=_("Mark Completion On Opening"),
-        help=_("Automatically mark this block as completed when content is loaded.")
+        help=_(
+            "Set to True for non-interactive or reading-only content to record progress on opening. "
+            "Leave False for interactive activities, which mark completion only after learner engagement."
+        )
     )
 
     h5p_content_meta = Dict(scope=Scope.content)

--- a/h5pxblock/h5pxblock.py
+++ b/h5pxblock/h5pxblock.py
@@ -169,6 +169,13 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
         scope=Scope.user_state,
     )
 
+    mark_completion_on_open = Boolean(
+        default=False,
+        scope=Scope.settings,
+        display_name=_("Mark Completion On Opening"),
+        help=_("Automatically mark this block as completed when content is loaded.")
+    )
+
     h5p_content_meta = Dict(scope=Scope.content)
     has_author_view = True
 
@@ -239,6 +246,7 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
             "weight": self.fields["weight"],
             "points": self.fields["points"],
             "h5p_xblock": self,
+            "mark_completion_on_open": self.fields["mark_completion_on_open"],
         }
 
     def author_view(self, context=None):
@@ -291,7 +299,8 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
                 "user_email": user.emails[0],
                 "userData": self.interaction_data,
                 "customJsPath": self.runtime.local_resource_url(self, "public/js/h5pcustom.js"),
-                "h5pJsonPath": self.h5p_content_json_path
+                "h5pJsonPath": self.h5p_content_json_path,
+                "mark_completion_on_open": self.mark_completion_on_open,
             }
         )
         return frag
@@ -324,6 +333,7 @@ class H5PPlayerXBlock(XBlock, CompletableXBlockMixin):
         points = request.params["points"]
         weight = request.params["weight"]
         self.points, self.weight = self.validate_score(points, weight)
+        self.mark_completion_on_open = str2bool(request.params["mark_completion_on_open"])
 
         if hasattr(request.params["h5p_content_bundle"], "file"):
             h5p_package = request.params["h5p_content_bundle"].file

--- a/h5pxblock/static/html/studio.html
+++ b/h5pxblock/static/html/studio.html
@@ -111,6 +111,24 @@
         </div>
         <span class="tip setting-help">{% trans is_scorable.help %}</span>
       </li>
+
+      <li class="field comp-setting-entry is-set">
+        <div class="wrapper-comp-setting">
+          <label class="label setting-label" for="xb_field_mark_completion_on_open">{% trans mark_completion_on_open.display_name %}</label>
+          <select class="field-data-control"
+                  id="xb_field_edit_mark_completion_on_open"
+                >
+                  <option value="1" {% if h5p_xblock.mark_completion_on_open %}selected{% endif %}>
+                    {% trans "True" %}{% if mark_completion_on_open.default %}&nbsp;&nbsp;&nbsp;&nbsp;{% trans "(Default)" %}{% endif %}
+                  </option>
+                  <option value="0" {% if not h5p_xblock.mark_completion_on_open %}selected{% endif %}>
+                    {% trans "False" %}{% if not mark_completion_on_open.default %}&nbsp;&nbsp;&nbsp;&nbsp;{% trans "(Default)" %}{% endif %}
+                  </option>
+          </select>
+        </div>
+        <span class="tip setting-help">{% trans mark_completion_on_open.help %}</span>
+      </li>
+
       <li class="field comp-setting-entry is-set scorable">
         <div class="wrapper-comp-setting">
           <label class="label setting-label" for="xb_weight">{% trans weight.display_name %}</label>

--- a/h5pxblock/static/js/src/h5pxblock.js
+++ b/h5pxblock/static/js/src/h5pxblock.js
@@ -33,7 +33,8 @@ function H5PPlayerXBlock(runtime, element, args) {
                 $(el).siblings('.spinner-container').find('.spinner-border').hide();
                 $(el).show();
 
-                // ✅ Auto-mark completion if enabled in Studio
+                // Auto-mark completion if enabled in Studio
+                // Source for verb: https://github.com/adlnet/xAPI-Spec/blob/master/xAPI-Data.md#verbs
                 if (args.mark_completion_on_open === true) {
                     $.ajax({
                         type: "POST",

--- a/h5pxblock/static/js/src/h5pxblock.js
+++ b/h5pxblock/static/js/src/h5pxblock.js
@@ -31,7 +31,24 @@ function H5PPlayerXBlock(runtime, element, args) {
 
             return new H5PStandalone.H5P(el, options).then(function(){ 
                 $(el).siblings('.spinner-container').find('.spinner-border').hide();
-                $(el).show();        
+                $(el).show();
+
+                // ✅ Auto-mark completion if enabled in Studio
+                if (args.mark_completion_on_open === true) {
+                    $.ajax({
+                        type: "POST",
+                        url: contentxResultSaveUrl,
+                        data: JSON.stringify({
+                            verb: {
+                                id: "http://adlnet.gov/expapi/verbs/experienced",
+                                display: {"en-US": "experienced"}
+                            },
+                            result: { completion: true }
+                        })
+                    });
+                }
+
+
                 H5P.externalDispatcher.on("xAPI", (event) => {
 
                     let hasStatement = event && event.data && event.data.statement;

--- a/h5pxblock/static/js/src/studio.js
+++ b/h5pxblock/static/js/src/studio.js
@@ -58,6 +58,7 @@ function H5PStudioXBlock(runtime, element, args) {
         var h5_content_path = $(element).find('#xb_existing_content_path').val();
         var weight = $(element).find('input[name=xb_weight]').val();
         var points = $(element).find('input[name=xb_points]').val();
+        var mark_completion_on_open = $(element).find('#xb_field_edit_mark_completion_on_open').val();
 
         form_data.append('h5p_content_bundle', h5p_content_bundle);
         form_data.append('display_name', display_name);
@@ -70,6 +71,7 @@ function H5PStudioXBlock(runtime, element, args) {
         form_data.append('h5_content_path', h5_content_path);
         form_data.append('weight', weight);
         form_data.append('points', points);
+        form_data.append('mark_completion_on_open', mark_completion_on_open);
 
         if ('notify' in runtime) { //xblock workbench runtime does not have `notify` method
             runtime.notify('save', { state: 'start' });

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def package_data(pkg, roots):
 
 setup(
     name='h5p-xblock',
-    version='0.2.9',
+    version='0.2.10',
     description='XBlock to play self hosted h5p content inside open edX',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Added a new Studio-configurable setting “Mark Completion On Opening” to the H5P XBlock that allows non-interactive H5P content to be automatically marked as completed when loaded. Updated frontend logic to send a completion event only if the block has not already been completed, preventing duplicate completion calls while preserving normal xAPI completion behavior for interactive content. By default this settings will be `false`

Jira: https://whoacademy.atlassian.net/browse/UC-501

Screenshot: 
<img width="1409" height="501" alt="image" src="https://github.com/user-attachments/assets/e6e5bddf-c4e4-46c2-8da9-089ec597581d" />
 